### PR TITLE
Fix versions, variables and add outputs.tf file

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "role" {
-  value = aws_iam_role.default
+  value       = aws_iam_role.default
+  description = "Direct aws_iam_role resource with all attributes"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,9 @@
 variable "buckets" {
-  type        = list
+  type        = list(any)
   description = "A list of bucket ARNs to allow access to"
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "Tags to apply to resources, where applicable"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` provider version.

It also adds missing output descriptions.

Once this is merged we can release v1.0.0 of this, so we can pin it as part of ministryofjustice/modernisation-platform#72.