### PR TITLE
feature/add-suffix-name-to-role-and-policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
 # S3 bucket replication: role
 resource "aws_iam_role" "default" {
-  name               = "AWSS3BucketReplication"
+  name               = "AWSS3BucketReplication${var.suffix_name}"
   assume_role_policy = data.aws_iam_policy_document.s3-assume-role-policy.json
   tags               = var.tags
 }
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "s3-assume-role-policy" {
 }
 
 resource "aws_iam_policy" "default" {
-  name   = "AWSS3BucketReplicationPolicy"
+  name   = "AWSS3BucketReplicationPolicy${var.suffix_name}"
   policy = data.aws_iam_policy_document.default-policy.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "tags" {
   type        = map(any)
   description = "Tags to apply to resources, where applicable"
 }
+
+variable "suffix_name" {
+  type = string
+  default = ""
+  description = "Suffix for role and policy names"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "tags" {
 }
 
 variable "suffix_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Suffix for role and policy names"
 }


### PR DESCRIPTION
Making changes to allow a name suffix for replication role module, this will allow multiple copies