### PR TITLE
Make tags variable optional: specify a default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "buckets" {
 variable "tags" {
   type        = map(any)
   description = "Tags to apply to resources, where applicable"
+  default     = {}
 }
 
 variable "suffix_name" {


### PR DESCRIPTION
This PR makes the tags variable optional by specifying a default value.

In terraform-provider-aws v3.38.0, you have the ability to [specify default tags for all resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#propagating-tags-to-all-resources) that are created using a provider.

This PR resolves an issue whereby if you specify default tags at the provider level but not at a module level, this module will raise an error saying `tags` are not specified.