### PR TITLE
various-updates-including-named-replication-bucket

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "buckets" {
   description = "A list of bucket ARNs to allow access to"
 }
 
+variable "replication_bucket" {
+  type        = string
+  description = "Name of bucket used for replication - if not specified then * will be used in the policy"
+  default     = ""
+}
+
 variable "tags" {
   type        = map(any)
   description = "Tags to apply to resources, where applicable"


### PR DESCRIPTION
- policy to include replication bucket name
- amend policy permissions

Update required to ensure encrypted objects are replicated and
permissions can be limited to a specific replication bucket