### PR TITLE
Fix providers to use testing-ci

### DIFF
--- a/test/unit-test/providers.tf
+++ b/test/unit-test/providers.tf
@@ -6,9 +6,9 @@ provider "aws" {
   }
 }
 
-# AWS provider for the Modernisation Platform, to get things from there if required
+# AWS provider for the testing-ci user (testing-test account), to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
+  alias                  = "testing-ci-user"
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
 }

--- a/test/unit-test/secrets.tf
+++ b/test/unit-test/secrets.tf
@@ -1,11 +1,16 @@
-# Get secret by name for environment management
+# Get secret by arn for environment management
+data "aws_ssm_parameter" "environment_management_arn" {
+  provider = aws.testing-ci-user
+  name     = "environment_management_arn"
+}
+
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
-  name     = "environment_management"
+  provider = aws.testing-ci-user
+  arn      = data.aws_ssm_parameter.environment_management_arn.value
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.testing-ci-user
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }


### PR DESCRIPTION
Tests were failing as using the incorrect provider to get the
environment secret.